### PR TITLE
Untiy2019のText描画における頂点数の仕様変更に対する修正

### DIFF
--- a/Assets/Hypertext/Examples/RegexHypertext.cs
+++ b/Assets/Hypertext/Examples/RegexHypertext.cs
@@ -62,18 +62,36 @@ namespace Hypertext
         /// </summary>
         protected override void AddListeners()
         {
+            var lineCount = CountChar(text, '\n') + 1;
+            bool hasFolded = lineCount != cachedTextGenerator.lineCount;
+
             foreach (var entry in entries)
             {
-#if UNITY_2019_1_OR_NEWER
-                var _text = text.Replace(" ", "").Replace("\n", "");
-#else
-                var _text = text;
-#endif
-                foreach (Match match in Regex.Matches(_text, entry.RegexPattern))
+                foreach (Match match in Regex.Matches(text, entry.RegexPattern))
                 {
+#if UNITY_2019_1_OR_NEWER
+                    if (hasFolded)
+                    {
+                        OnClick(match.Index, match.Value.Length, entry.Color, entry.Callback);
+                    }
+                    else
+                    {
+                        // 折り返していない場合のみ「空白」と「改行」が描画されないため、調整する
+                        var head = text.Substring(0, match.Index);
+                        var count = CountChar(head, ' ') + CountChar(head, '\n');
+                        OnClick(match.Index - count, match.Value.Length, entry.Color, entry.Callback);
+                    }
+#else
                     OnClick(match.Index, match.Value.Length, entry.Color, entry.Callback);
+#endif
                 }
             }
+        }
+
+        // 文字の出現回数をカウント
+        public static int CountChar(string s, char c)
+        {
+            return s.Length - s.Replace(c.ToString(), "").Length;
         }
     }
 }

--- a/Assets/Hypertext/Examples/RegexHypertext.cs
+++ b/Assets/Hypertext/Examples/RegexHypertext.cs
@@ -64,7 +64,12 @@ namespace Hypertext
         {
             foreach (var entry in entries)
             {
-                foreach (Match match in Regex.Matches(text, entry.RegexPattern))
+#if UNITY_2019_1_OR_NEWER
+                var _text = text.Replace(" ", "").Replace("\n", "");
+#else
+                var _text = text;
+#endif
+                foreach (Match match in Regex.Matches(_text, entry.RegexPattern))
                 {
                     OnClick(match.Index, match.Value.Length, entry.Color, entry.Callback);
                 }

--- a/Assets/Hypertext/Examples/RegexHypertext.cs
+++ b/Assets/Hypertext/Examples/RegexHypertext.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text.RegularExpressions;
 using UnityEngine;
 
@@ -62,7 +63,7 @@ namespace Hypertext
         /// </summary>
         protected override void AddListeners()
         {
-            var lineCount = CountChar(text, '\n') + 1;
+            var lineCount = text.Count(x => x == '\n') + 1;
             bool hasFolded = lineCount != cachedTextGenerator.lineCount;
 
             foreach (var entry in entries)
@@ -78,7 +79,7 @@ namespace Hypertext
                     {
                         // 折り返していない場合のみ「空白」と「改行」が描画されないため、調整する
                         var head = text.Substring(0, match.Index);
-                        var count = CountChar(head, ' ') + CountChar(head, '\n');
+                        var count = head.Count(x => x == ' ') + head.Count(x => x == '\n');
                         OnClick(match.Index - count, match.Value.Length, entry.Color, entry.Callback);
                     }
 #else
@@ -86,12 +87,6 @@ namespace Hypertext
 #endif
                 }
             }
-        }
-
-        // 文字の出現回数をカウント
-        public static int CountChar(string s, char c)
-        {
-            return s.Length - s.Replace(c.ToString(), "").Length;
         }
     }
 }


### PR DESCRIPTION
# 概要

Unity2019.1以降でTextの頂点数の変わっていたため`RegexHypertext`が動作しなくなっていた問題に対処した。

# 詳細

Unity2019.1.10f1でサンプルシーンを開くと以下のようになっていました。

<img width="287" alt="スクリーンショット 2019-10-29 11 59 36" src="https://user-images.githubusercontent.com/7017772/67737942-3d0b7700-fa50-11e9-966d-64c0c936cfc0.png">

ハイライトされる位置がずれていることが確認できます。

そこでサンプルシーンの頂点数を異なるバージョンのエディターで比較しました。

- Unity2018.4.11f1のVerts: 250
- Unity2019.1.10f1のVerts: 232

18頂点分の差分が生まれています。uGUIでは1文字を6頂点で描画するため、3文字分に相当すると考えました。

そこで正規表現をする前のテキストから空白(2個所)と改行(1個所)を取り除いたところ、正しく表示されました。恐らくUnity2019.1以降ではこれらの頂点が描画されない仕様になったのではないでしょうか。

そこでプルリクの修正を行い、それぞれのバージョンで以下のように正しく描画されることを確認しました。

<img width="763" alt="Unity2018 4 11f1" src="https://user-images.githubusercontent.com/7017772/67737742-b5256d00-fa4f-11e9-8e30-07148c572a6b.png">
<img width="772" alt="Unity2019 1 10f1" src="https://user-images.githubusercontent.com/7017772/67737743-b6569a00-fa4f-11e9-8b38-0971b97740be.png">

ご確認よろしくお願いします。
